### PR TITLE
u-boot-stm32mp: update u-boot patches for latest kirkstone version

### DIFF
--- a/recipes-bsp/u-boot/u-boot-stm32mp/0001-stm32mp135-gea-Basic-porting.patch
+++ b/recipes-bsp/u-boot/u-boot-stm32mp/0001-stm32mp135-gea-Basic-porting.patch
@@ -1,4 +1,4 @@
-From d3da2b468fde8abe832a27965875607c69263365 Mon Sep 17 00:00:00 2001
+From 73b003696c3832bcfcce48c402b9317d84d0e530 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Fri, 22 Jul 2022 17:13:58 +0200
 Subject: [PATCH] stm32mp135 gea - Basic porting
@@ -14,19 +14,19 @@ Subject: [PATCH] stm32mp135 gea - Basic porting
  create mode 100644 arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts.bak
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 6ddf3cbeba..5f2848cfb2 100644
+index 1146cd5753..f13c21835e 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -1082,7 +1082,8 @@ dtb-$(CONFIG_ARCH_STI) += stih410-b2260.dtb
+@@ -1081,7 +1081,8 @@ dtb-$(CONFIG_ASPEED_AST2600) += ast2600-evb.dtb
+ dtb-$(CONFIG_ARCH_STI) += stih410-b2260.dtb
  
  dtb-$(CONFIG_STM32MP13x) += \
- 	stm32mp135d-dk.dtb \
 -	stm32mp135f-dk.dtb
 +	stm32mp135f-dk.dtb \
 +	stm32mp135d-gea-starterkit-mx.dtb
  
  dtb-$(CONFIG_STM32MP15x) += \
- 	stm32mp157a-avenger96.dtb \
+ 	stm32mp157a-dk1.dtb \
 diff --git a/arch/arm/dts/stm32mp135d-gea-starterkit-mx-u-boot.dtsi b/arch/arm/dts/stm32mp135d-gea-starterkit-mx-u-boot.dtsi
 new file mode 100644
 index 0000000000..8a60048a63

--- a/recipes-bsp/u-boot/u-boot-stm32mp/0002-stm32mp135-gea-Enabled-connectivity-peripherals.patch
+++ b/recipes-bsp/u-boot/u-boot-stm32mp/0002-stm32mp135-gea-Enabled-connectivity-peripherals.patch
@@ -1,4 +1,4 @@
-From f743b47f38b32224817ed659b70314665f3314fd Mon Sep 17 00:00:00 2001
+From 5a101ec46252d4f6dd8e7f7427ae8857a298fc0e Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Wed, 27 Jul 2022 11:11:26 +0200
 Subject: [PATCH] stm32mp135 gea - Enabled connectivity peripherals

--- a/recipes-bsp/u-boot/u-boot-stm32mp/0003-stm32mp135-gea-on-starterkit-Enabled-parallel-displa.patch
+++ b/recipes-bsp/u-boot/u-boot-stm32mp/0003-stm32mp135-gea-on-starterkit-Enabled-parallel-displa.patch
@@ -1,4 +1,4 @@
-From 551169ffd9b14067ef7949fb36f6c41bf67c5b93 Mon Sep 17 00:00:00 2001
+From 234c91c12cad5357ad84b0a4a30aa008d5ee8c58 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Fri, 29 Jul 2022 16:55:45 +0200
 Subject: [PATCH] stm32mp135 gea on starterkit - Enabled parallel display and

--- a/recipes-bsp/u-boot/u-boot-stm32mp/0004-stm32mp135-gea-on-starterkit-Ported-eMMC.patch
+++ b/recipes-bsp/u-boot/u-boot-stm32mp/0004-stm32mp135-gea-on-starterkit-Ported-eMMC.patch
@@ -1,4 +1,4 @@
-From 132187d8d763729cfae6747ac9d38170e745b628 Mon Sep 17 00:00:00 2001
+From aafd7b156dad9db43aa0774193ee552404c9c729 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Wed, 10 Aug 2022 16:47:39 +0200
 Subject: [PATCH] stm32mp135 gea on starterkit - Ported eMMC

--- a/recipes-bsp/u-boot/u-boot-stm32mp/0005-stm32mp135-ugea-porting-on-microdev2.0.patch
+++ b/recipes-bsp/u-boot/u-boot-stm32mp/0005-stm32mp135-ugea-porting-on-microdev2.0.patch
@@ -1,4 +1,4 @@
-From 72aab52923427931efd5ffdef47808100d4f16ed Mon Sep 17 00:00:00 2001
+From f9e9d778a0687db06f9c05aeb595784d581abd17 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Tue, 4 Oct 2022 17:47:37 +0200
 Subject: [PATCH] stm32mp135-ugea-porting-on-microdev2.0
@@ -14,19 +14,19 @@ Subject: [PATCH] stm32mp135-ugea-porting-on-microdev2.0
  create mode 100644 arch/arm/dts/stm32mp135d-microgea-microdev-mx.dts.bak
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 5f2848cfb2..98e10a7ec9 100644
+index f13c21835e..cc73aaf1c5 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -1083,7 +1083,8 @@ dtb-$(CONFIG_ARCH_STI) += stih410-b2260.dtb
+@@ -1082,7 +1082,8 @@ dtb-$(CONFIG_ARCH_STI) += stih410-b2260.dtb
+ 
  dtb-$(CONFIG_STM32MP13x) += \
- 	stm32mp135d-dk.dtb \
  	stm32mp135f-dk.dtb \
 -	stm32mp135d-gea-starterkit-mx.dtb
 +	stm32mp135d-gea-starterkit-mx.dtb \
 +	stm32mp135d-microgea-microdev-mx.dtb
  
  dtb-$(CONFIG_STM32MP15x) += \
- 	stm32mp157a-avenger96.dtb \
+ 	stm32mp157a-dk1.dtb \
 diff --git a/arch/arm/dts/stm32mp135d-microgea-microdev-mx-u-boot.dtsi b/arch/arm/dts/stm32mp135d-microgea-microdev-mx-u-boot.dtsi
 new file mode 100644
 index 0000000000..7ee3f46d86

--- a/recipes-kernel/linux/linux-stm32mp/0001-stm32mp135-gea-Basic-porting.patch
+++ b/recipes-kernel/linux/linux-stm32mp/0001-stm32mp135-gea-Basic-porting.patch
@@ -1,4 +1,4 @@
-From 8d23908422f9202a01faeab0f806778ce10f3961 Mon Sep 17 00:00:00 2001
+From 8467951986cfb6b740f44dc48c1b99c5cfa49b72 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Fri, 22 Jul 2022 17:14:42 +0200
 Subject: [PATCH] stm32mp135 gea - Basic porting
@@ -10,11 +10,11 @@ Subject: [PATCH] stm32mp135 gea - Basic porting
  create mode 100644 arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
 
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index 09460432d..fe9f72c7a 100644
+index 1f07bf84c..c671ec315 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -1154,6 +1154,7 @@ dtb-$(CONFIG_ARCH_STM32) += \
- 	stm32mp135d-dk-a7-examples.dtb \
+@@ -1155,6 +1155,7 @@ dtb-$(CONFIG_ARCH_STM32) += \
+ 	stm32h750i-art-pi.dtb \
  	stm32mp135f-dk.dtb \
  	stm32mp135f-dk-a7-examples.dtb \
 +	stm32mp135d-gea-starterkit-mx.dtb \
@@ -23,7 +23,7 @@ index 09460432d..fe9f72c7a 100644
  	stm32mp157a-dhcor-avenger96.dtb \
 diff --git a/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
 new file mode 100644
-index 000000000..a7401bac2
+index 000000000..7cfad4c49
 --- /dev/null
 +++ b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
 @@ -0,0 +1,354 @@

--- a/recipes-kernel/linux/linux-stm32mp/0002-stm32mp135-gea-Enabled-connectivity-peripherals.patch
+++ b/recipes-kernel/linux/linux-stm32mp/0002-stm32mp135-gea-Enabled-connectivity-peripherals.patch
@@ -1,4 +1,4 @@
-From fe54090134ae6a76270325a954dd514685e9f48a Mon Sep 17 00:00:00 2001
+From 3df0d1cc2f9efb893058c26cbbc5872512edb77e Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Wed, 27 Jul 2022 11:14:01 +0200
 Subject: [PATCH] stm32mp135 gea - Enabled connectivity peripherals
@@ -8,7 +8,7 @@ Subject: [PATCH] stm32mp135 gea - Enabled connectivity peripherals
  1 file changed, 336 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
-index a7401bac2..0d193ead6 100644
+index 7cfad4c49..a2702e207 100644
 --- a/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
 +++ b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
 @@ -15,6 +15,10 @@
@@ -22,7 +22,7 @@ index a7401bac2..0d193ead6 100644
  /* USER CODE END includes */
  
  / {
-@@ -49,8 +53,8 @@
+@@ -49,8 +53,8 @@ optee@de000000 {
  
  	/* USER CODE BEGIN root */
  	aliases {
@@ -33,7 +33,7 @@ index a7401bac2..0d193ead6 100644
  		serial0 = &uart4;
  		serial1 = &uart8;
  		serial2 = &usart2;
-@@ -90,6 +94,124 @@
+@@ -90,6 +94,124 @@ clocks {
  
  &pinctrl {
  
@@ -158,7 +158,7 @@ index a7401bac2..0d193ead6 100644
  	sdmmc1_pins_mx: sdmmc1_mx-0 {
  		pins1 {
  			pinmux = <STM32_PINMUX('C', 8, AF12)>, /* SDMMC1_D0 */
-@@ -218,6 +340,62 @@
+@@ -218,6 +340,62 @@ pins {
  		};
  	};
  
@@ -221,7 +221,7 @@ index a7401bac2..0d193ead6 100644
  	/* USER CODE BEGIN pinctrl */
  	/* USER CODE END pinctrl */
  };
-@@ -253,6 +431,85 @@
+@@ -253,6 +431,85 @@ &dmamux1{
  	/* USER CODE END dmamux1 */
  };
  
@@ -307,7 +307,7 @@ index a7401bac2..0d193ead6 100644
  &mdma{
  	status = "okay";
  
-@@ -286,7 +543,6 @@
+@@ -286,7 +543,6 @@ &sdmmc1{
  	disable-wp;
  	st,neg-edge;
  	bus-width = <4>;
@@ -315,7 +315,7 @@ index a7401bac2..0d193ead6 100644
  	vmmc-supply = <&v3v3_ao>;
  	/* USER CODE END sdmmc1 */
  };
-@@ -316,6 +572,83 @@
+@@ -316,6 +572,83 @@ &uart4{
  	/* USER CODE END uart4 */
  };
  

--- a/recipes-kernel/linux/linux-stm32mp/0003-stm32mp135-gea-on-starterkit-Enabled-parallel-displa.patch
+++ b/recipes-kernel/linux/linux-stm32mp/0003-stm32mp135-gea-on-starterkit-Enabled-parallel-displa.patch
@@ -1,4 +1,4 @@
-From 2ac30b6551e7021a72cc636de8e66cfc7dfe3804 Mon Sep 17 00:00:00 2001
+From 5c0cacdc1038bdaae8e970329799626dbaec7aa5 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Fri, 29 Jul 2022 16:57:01 +0200
 Subject: [PATCH] stm32mp135 gea on starterkit - Enabled parallel display and
@@ -9,10 +9,10 @@ Subject: [PATCH] stm32mp135 gea on starterkit - Enabled parallel display and
  1 file changed, 155 insertions(+)
 
 diff --git a/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
-index 0d193ead6..765706c99 100644
+index a2702e207..f943f6d30 100644
 --- a/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
 +++ b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
-@@ -82,6 +82,48 @@
+@@ -82,6 +82,48 @@ v3v3_ao: v3v3_ao {
  		regulator-max-microvolt = <3300000>;
  		regulator-always-on;
  	};
@@ -61,7 +61,7 @@ index 0d193ead6..765706c99 100644
  	/* USER CODE END root */
  
  	clocks {
-@@ -212,6 +254,85 @@
+@@ -212,6 +254,85 @@ pins {
  		};
  	};
  
@@ -147,7 +147,7 @@ index 0d193ead6..765706c99 100644
  	sdmmc1_pins_mx: sdmmc1_mx-0 {
  		pins1 {
  			pinmux = <STM32_PINMUX('C', 8, AF12)>, /* SDMMC1_D0 */
-@@ -490,6 +611,39 @@
+@@ -490,6 +611,39 @@ phy0_eth2: ethernet-phy@0 {
  	/* USER CODE END eth2 */
  };
  
@@ -187,7 +187,7 @@ index 0d193ead6..765706c99 100644
  &m_can1{
  	pinctrl-names = "default", "sleep";
  	pinctrl-0 = <&fdcan1_pins_mx>;
-@@ -685,3 +839,4 @@
+@@ -685,3 +839,4 @@ scmi_v3v3_sw: voltd-v3v3_sw {
  	};
  };
  /* USER CODE END addons */

--- a/recipes-kernel/linux/linux-stm32mp/0004-stm32mp135-gea-on-starterkit-Ported-eMMC.patch
+++ b/recipes-kernel/linux/linux-stm32mp/0004-stm32mp135-gea-on-starterkit-Ported-eMMC.patch
@@ -1,4 +1,4 @@
-From ebfc7b88574e6ca58695fda1d1849dbf96814b81 Mon Sep 17 00:00:00 2001
+From 9f6a05037ef8bdb5a6b6ea720e255123e455f78b Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Wed, 10 Aug 2022 16:51:58 +0200
 Subject: [PATCH] stm32mp135 gea on starterkit - Ported eMMC
@@ -8,10 +8,10 @@ Subject: [PATCH] stm32mp135 gea on starterkit - Ported eMMC
  1 file changed, 23 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
-index 765706c99..6590e674a 100644
+index f943f6d30..40ccb553f 100644
 --- a/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
 +++ b/arch/arm/boot/dts/stm32mp135d-gea-starterkit-mx.dts
-@@ -399,6 +399,15 @@
+@@ -399,6 +399,15 @@ pins1 {
  			slew-rate = <1>;
  		};
  		pins2 {
@@ -27,7 +27,7 @@ index 765706c99..6590e674a 100644
  			pinmux = <STM32_PINMUX('E', 3, AF10)>; /* SDMMC2_CK */
  			bias-pull-up;
  			drive-push-pull;
-@@ -417,12 +426,21 @@
+@@ -417,12 +426,21 @@ pins1 {
  			slew-rate = <1>;
  		};
  		pins2 {
@@ -50,7 +50,7 @@ index 765706c99..6590e674a 100644
  			pinmux = <STM32_PINMUX('G', 6, AF10)>; /* SDMMC2_CMD */
  			bias-pull-up;
  			drive-open-drain;
-@@ -434,9 +452,13 @@
+@@ -434,9 +452,13 @@ sdmmc2_sleep_pins_mx: sdmmc2_sleep_mx-0 {
  		pins {
  			pinmux = <STM32_PINMUX('B', 3, ANALOG)>, /* SDMMC2_D2 */
  					 <STM32_PINMUX('B', 4, ANALOG)>, /* SDMMC2_D3 */

--- a/recipes-kernel/linux/linux-stm32mp/0005-Added-I2C-touchscreen-driver-EDT-FocalTech-FT5x26.patch
+++ b/recipes-kernel/linux/linux-stm32mp/0005-Added-I2C-touchscreen-driver-EDT-FocalTech-FT5x26.patch
@@ -1,4 +1,4 @@
-From cc03e18972f8ba08c6eea1a11564b7c414607070 Mon Sep 17 00:00:00 2001
+From 38eb33802bdfaa5c401617e835794207fffecedc Mon Sep 17 00:00:00 2001
 From: frautel <francesco.utel@engicam.com>
 Date: Thu, 10 Feb 2022 14:24:28 +0100
 Subject: [PATCH] Added I2C touchscreen driver EDT FocalTech FT5x26
@@ -11,10 +11,10 @@ Subject: [PATCH] Added I2C touchscreen driver EDT FocalTech FT5x26
  create mode 100644 drivers/input/touchscreen/edt-ft5x26.c
 
 diff --git a/drivers/input/touchscreen/Kconfig b/drivers/input/touchscreen/Kconfig
-index cc18f54ea..d68af9968 100644
+index d4e74738c..f810f3e93 100644
 --- a/drivers/input/touchscreen/Kconfig
 +++ b/drivers/input/touchscreen/Kconfig
-@@ -731,6 +731,19 @@ config TOUCHSCREEN_EDT_FT5X06
+@@ -741,6 +741,19 @@ config TOUCHSCREEN_EDT_FT5X06
  	  To compile this driver as a module, choose M here: the
  	  module will be called edt-ft5x06.
  
@@ -35,10 +35,10 @@ index cc18f54ea..d68af9968 100644
  	tristate "Raspberry Pi's firmware base touch screen support"
  	depends on RASPBERRYPI_FIRMWARE || (RASPBERRYPI_FIRMWARE=n && COMPILE_TEST)
 diff --git a/drivers/input/touchscreen/Makefile b/drivers/input/touchscreen/Makefile
-index 6233541e9..8be01f2c3 100644
+index 7d34100f7..39e915107 100644
 --- a/drivers/input/touchscreen/Makefile
 +++ b/drivers/input/touchscreen/Makefile
-@@ -32,6 +32,7 @@ obj-$(CONFIG_TOUCHSCREEN_DA9034)	+= da9034-ts.o
+@@ -33,6 +33,7 @@ obj-$(CONFIG_TOUCHSCREEN_DA9034)	+= da9034-ts.o
  obj-$(CONFIG_TOUCHSCREEN_DA9052)	+= da9052_tsi.o
  obj-$(CONFIG_TOUCHSCREEN_DYNAPRO)	+= dynapro.o
  obj-$(CONFIG_TOUCHSCREEN_EDT_FT5X06)	+= edt-ft5x06.o

--- a/recipes-kernel/linux/linux-stm32mp/0006-stm32mp135-ugea-porting-on-microdev2.0.patch
+++ b/recipes-kernel/linux/linux-stm32mp/0006-stm32mp135-ugea-porting-on-microdev2.0.patch
@@ -1,4 +1,4 @@
-From aff389efb3f4e6844094c8a54d38c280b81e10ac Mon Sep 17 00:00:00 2001
+From ccfc5e63d8044cafc2276f81a95761eca6797ae0 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Tue, 4 Oct 2022 17:48:15 +0200
 Subject: [PATCH] stm32mp135-ugea-porting-on-microdev2.0
@@ -10,10 +10,10 @@ Subject: [PATCH] stm32mp135-ugea-porting-on-microdev2.0
  create mode 100644 arch/arm/boot/dts/stm32mp135d-microgea-microdev-mx.dts
 
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index fe9f72c7a..0ced9aaf0 100644
+index c671ec315..6aa05bbed 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -1155,6 +1155,7 @@ dtb-$(CONFIG_ARCH_STM32) += \
+@@ -1156,6 +1156,7 @@ dtb-$(CONFIG_ARCH_STM32) += \
  	stm32mp135f-dk.dtb \
  	stm32mp135f-dk-a7-examples.dtb \
  	stm32mp135d-gea-starterkit-mx.dtb \
@@ -23,7 +23,7 @@ index fe9f72c7a..0ced9aaf0 100644
  	stm32mp157a-dhcor-avenger96.dtb \
 diff --git a/arch/arm/boot/dts/stm32mp135d-microgea-microdev-mx.dts b/arch/arm/boot/dts/stm32mp135d-microgea-microdev-mx.dts
 new file mode 100644
-index 000000000..8ac462d72
+index 000000000..0b80acae6
 --- /dev/null
 +++ b/arch/arm/boot/dts/stm32mp135d-microgea-microdev-mx.dts
 @@ -0,0 +1,731 @@

--- a/recipes-kernel/linux/linux-stm32mp/0007-stm32mp135-ugea-Fixed-usart2-pinmux-on-microdev2.0.patch
+++ b/recipes-kernel/linux/linux-stm32mp/0007-stm32mp135-ugea-Fixed-usart2-pinmux-on-microdev2.0.patch
@@ -1,4 +1,4 @@
-From 4cc5972afda1aa6be00c664711e2276e6a14975e Mon Sep 17 00:00:00 2001
+From 651790b027ae35919f7269e86ae7ade4a1aeab78 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Mon, 7 Nov 2022 15:51:02 +0100
 Subject: [PATCH] stm32mp135 ugea Fixed usart2 pinmux on microdev2.0
@@ -11,7 +11,7 @@ diff --git a/arch/arm/boot/dts/stm32mp135d-microgea-microdev-mx.dts b/arch/arm/b
 index 0b80acae6..53239d67f 100644
 --- a/arch/arm/boot/dts/stm32mp135d-microgea-microdev-mx.dts
 +++ b/arch/arm/boot/dts/stm32mp135d-microgea-microdev-mx.dts
-@@ -445,12 +445,12 @@
+@@ -445,12 +445,12 @@ pins {
  
  	usart2_pins_mx: usart2_mx-0 {
  		pins1 {
@@ -27,7 +27,7 @@ index 0b80acae6..53239d67f 100644
  			bias-disable;
  			drive-push-pull;
  			slew-rate = <0>;
-@@ -459,7 +459,7 @@
+@@ -459,7 +459,7 @@ pins2 {
  
  	usart2_sleep_pins_mx: usart2_sleep_mx-0 {
  		pins {

--- a/recipes-security/optee/optee-os-stm32mp/0001-stm32mp135-gea-Basic-porting.patch
+++ b/recipes-security/optee/optee-os-stm32mp/0001-stm32mp135-gea-Basic-porting.patch
@@ -1,17 +1,17 @@
-From 77f79964d3f06cf477ac58ee65045e569f42c21b Mon Sep 17 00:00:00 2001
+From 4e21105ef6857837aa9ee3333216b6ccae8e6285 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Fri, 22 Jul 2022 17:14:20 +0200
 Subject: [PATCH] stm32mp135 gea - Basic porting
 
 ---
  .../arm/dts/stm32mp135d-gea-starterkit-mx.dts | 524 ++++++++++++++++++
- core/arch/arm/plat-stm32mp1/conf.mk           |   2 +
- 2 files changed, 526 insertions(+)
+ core/arch/arm/plat-stm32mp1/conf.mk           |   4 +-
+ 2 files changed, 527 insertions(+), 1 deletion(-)
  create mode 100644 core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 
 diff --git a/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 new file mode 100644
-index 00000000..6118bed5
+index 000000000..c40ab1629
 --- /dev/null
 +++ b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 @@ -0,0 +1,524 @@
@@ -540,22 +540,24 @@ index 00000000..6118bed5
 +};
 +/* USER CODE END addons */
 diff --git a/core/arch/arm/plat-stm32mp1/conf.mk b/core/arch/arm/plat-stm32mp1/conf.mk
-index 23e82adb..d3f79412 100644
+index 05229e61e..18be82d1e 100644
 --- a/core/arch/arm/plat-stm32mp1/conf.mk
 +++ b/core/arch/arm/plat-stm32mp1/conf.mk
-@@ -12,6 +12,7 @@ flavor_dts_file-157F_DK2 = stm32mp157f-dk2.dts
- flavor_dts_file-157F_ED1 = stm32mp157f-ed1.dts
- flavor_dts_file-157F_EV1 = stm32mp157f-ev1.dts
- flavor_dts_file-135D_DK = stm32mp135d-dk.dts
+@@ -6,6 +6,7 @@ flavor_dts_file-157C_DK2 = stm32mp157c-dk2.dts
+ flavor_dts_file-157C_ED1 = stm32mp157c-ed1.dts
+ flavor_dts_file-157C_EV1 = stm32mp157c-ev1.dts
+ flavor_dts_file-157D_DK1 = stm32mp157d-dk1.dts
 +flavor_dts_file-135D_EN_STARTERKIT = stm32mp135d-gea-starterkit-mx.dts
- flavor_dts_file-135F_DK = stm32mp135f-dk.dts
- 
- flavorlist-512M = $(flavor_dts_file-157A_DK1) \
-@@ -19,6 +20,7 @@ flavorlist-512M = $(flavor_dts_file-157A_DK1) \
+ flavor_dts_file-157D_ED1 = stm32mp157d-ed1.dts
+ flavor_dts_file-157D_EV1 = stm32mp157d-ev1.dts
+ flavor_dts_file-157F_DK2 = stm32mp157f-dk2.dts
+@@ -17,7 +18,8 @@ flavorlist-512M = $(flavor_dts_file-157A_DK1) \
+ 		  $(flavor_dts_file-157C_DK2) \
  		  $(flavor_dts_file-157D_DK1) \
  		  $(flavor_dts_file-157F_DK2) \
- 		  $(flavor_dts_file-135D_DK) \
-+			$(flavor_dts_file-135D_EN_STARTERKIT) \
- 		  $(flavor_dts_file-135F_DK)
+-		  $(flavor_dts_file-135F_DK)
++		  $(flavor_dts_file-135F_DK) \
++		  $(flavor_dts_file-135D_EN_STARTERKIT)
  
  flavorlist-1G = $(flavor_dts_file-157A_ED1) \
+ 		$(flavor_dts_file-157A_EV1) \

--- a/recipes-security/optee/optee-os-stm32mp/0002-stm32mp135-gea-Enabled-connectivity-peripherals.patch
+++ b/recipes-security/optee/optee-os-stm32mp/0002-stm32mp135-gea-Enabled-connectivity-peripherals.patch
@@ -1,4 +1,4 @@
-From 1470c92a6e9d0e4083c228b7338873a179c26656 Mon Sep 17 00:00:00 2001
+From f358336002ba115ce5f979fd8038cd6f13b24893 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Wed, 27 Jul 2022 11:10:15 +0200
 Subject: [PATCH] stm32mp135 gea - Enabled connectivity peripherals
@@ -8,7 +8,7 @@ Subject: [PATCH] stm32mp135 gea - Enabled connectivity peripherals
  1 file changed, 67 insertions(+), 1 deletion(-)
 
 diff --git a/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
-index 6118bed5..b3041448 100644
+index c40ab1629..570e947c5 100644
 --- a/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 +++ b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 @@ -150,8 +150,13 @@

--- a/recipes-security/optee/optee-os-stm32mp/0003-stm32mp135-gea-on-starterkit-Enabled-parallel-displa.patch
+++ b/recipes-security/optee/optee-os-stm32mp/0003-stm32mp135-gea-on-starterkit-Enabled-parallel-displa.patch
@@ -1,4 +1,4 @@
-From 9df7c7d4cf48dc90397de9d0a7b261c4271f1348 Mon Sep 17 00:00:00 2001
+From a33e0d2e7bfd453ddc2639c3b39dc5505364bb36 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Fri, 29 Jul 2022 16:53:54 +0200
 Subject: [PATCH] stm32mp135 gea on starterkit - Enabled parallel display and
@@ -9,7 +9,7 @@ Subject: [PATCH] stm32mp135 gea on starterkit - Enabled parallel display and
  1 file changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
-index b3041448..3237eac5 100644
+index 570e947c5..990235865 100644
 --- a/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 +++ b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 @@ -152,6 +152,7 @@

--- a/recipes-security/optee/optee-os-stm32mp/0004-Configured-i2c5-pull-up-resistance.patch
+++ b/recipes-security/optee/optee-os-stm32mp/0004-Configured-i2c5-pull-up-resistance.patch
@@ -1,4 +1,4 @@
-From 28393abc115622f2c404fa452318a666c57eb106 Mon Sep 17 00:00:00 2001
+From 554d7be49e723eafbca0e6667a4f21a65c0b9f64 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Wed, 10 Aug 2022 16:41:53 +0200
 Subject: [PATCH] Configured i2c5 pull up resistance
@@ -8,7 +8,7 @@ Subject: [PATCH] Configured i2c5 pull up resistance
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
-index 3237eac5..3f055f92 100644
+index 990235865..62d4cd473 100644
 --- a/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 +++ b/core/arch/arm/dts/stm32mp135d-gea-starterkit-mx.dts
 @@ -116,7 +116,7 @@

--- a/recipes-security/optee/optee-os-stm32mp/0005-stm32mp135-ugea-porting-on-microdev2.0.patch
+++ b/recipes-security/optee/optee-os-stm32mp/0005-stm32mp135-ugea-porting-on-microdev2.0.patch
@@ -1,17 +1,17 @@
-From f1bd5eab4664f4356ddebe4e1b8ae482883bfd28 Mon Sep 17 00:00:00 2001
+From 00d7a1108e64e749453174ddbe71e66ad3298899 Mon Sep 17 00:00:00 2001
 From: Franesco Utel <francesco.utel@engicam.com>
 Date: Tue, 4 Oct 2022 17:46:56 +0200
 Subject: [PATCH] stm32mp135-ugea-porting-on-microdev2.0
 
 ---
  .../dts/stm32mp135d-microgea-microdev-mx.dts  | 471 ++++++++++++++++++
- core/arch/arm/plat-stm32mp1/conf.mk           |   2 +
- 2 files changed, 473 insertions(+)
+ core/arch/arm/plat-stm32mp1/conf.mk           |   4 +-
+ 2 files changed, 474 insertions(+), 1 deletion(-)
  create mode 100644 core/arch/arm/dts/stm32mp135d-microgea-microdev-mx.dts
 
 diff --git a/core/arch/arm/dts/stm32mp135d-microgea-microdev-mx.dts b/core/arch/arm/dts/stm32mp135d-microgea-microdev-mx.dts
 new file mode 100644
-index 00000000..661cdd40
+index 000000000..01072aad0
 --- /dev/null
 +++ b/core/arch/arm/dts/stm32mp135d-microgea-microdev-mx.dts
 @@ -0,0 +1,471 @@
@@ -487,22 +487,24 @@ index 00000000..661cdd40
 +};
 +/* USER CODE END addons */
 diff --git a/core/arch/arm/plat-stm32mp1/conf.mk b/core/arch/arm/plat-stm32mp1/conf.mk
-index d3f79412..868b5c71 100644
+index 18be82d1e..4a12eb2ca 100644
 --- a/core/arch/arm/plat-stm32mp1/conf.mk
 +++ b/core/arch/arm/plat-stm32mp1/conf.mk
-@@ -13,6 +13,7 @@ flavor_dts_file-157F_ED1 = stm32mp157f-ed1.dts
- flavor_dts_file-157F_EV1 = stm32mp157f-ev1.dts
- flavor_dts_file-135D_DK = stm32mp135d-dk.dts
+@@ -7,6 +7,7 @@ flavor_dts_file-157C_ED1 = stm32mp157c-ed1.dts
+ flavor_dts_file-157C_EV1 = stm32mp157c-ev1.dts
+ flavor_dts_file-157D_DK1 = stm32mp157d-dk1.dts
  flavor_dts_file-135D_EN_STARTERKIT = stm32mp135d-gea-starterkit-mx.dts
 +flavor_dts_file-135D_EN_MICRODEV = stm32mp135d-microgea-microdev-mx.dts
- flavor_dts_file-135F_DK = stm32mp135f-dk.dts
- 
- flavorlist-512M = $(flavor_dts_file-157A_DK1) \
-@@ -21,6 +22,7 @@ flavorlist-512M = $(flavor_dts_file-157A_DK1) \
+ flavor_dts_file-157D_ED1 = stm32mp157d-ed1.dts
+ flavor_dts_file-157D_EV1 = stm32mp157d-ev1.dts
+ flavor_dts_file-157F_DK2 = stm32mp157f-dk2.dts
+@@ -19,7 +20,8 @@ flavorlist-512M = $(flavor_dts_file-157A_DK1) \
+ 		  $(flavor_dts_file-157D_DK1) \
  		  $(flavor_dts_file-157F_DK2) \
- 		  $(flavor_dts_file-135D_DK) \
- 			$(flavor_dts_file-135D_EN_STARTERKIT) \
-+			$(flavor_dts_file-135D_EN_MICRODEV) \
- 		  $(flavor_dts_file-135F_DK)
+ 		  $(flavor_dts_file-135F_DK) \
+-		  $(flavor_dts_file-135D_EN_STARTERKIT)
++		  $(flavor_dts_file-135D_EN_STARTERKIT) \
++		  $(flavor_dts_file-135D_EN_MICRODEV)
  
  flavorlist-1G = $(flavor_dts_file-157A_ED1) \
+ 		$(flavor_dts_file-157A_EV1) \


### PR DESCRIPTION
Patches cannot cleanly apply on the u-boot version provided by the original recipe for kirkstone branch.